### PR TITLE
Modularize ClockUtils

### DIFF
--- a/app/src/main/java/com/mymeetings/android/utils/ClockUtils.kt
+++ b/app/src/main/java/com/mymeetings/android/utils/ClockUtils.kt
@@ -9,13 +9,17 @@ import java.util.*
 class ClockUtils {
     fun currentTimeMillis() = System.currentTimeMillis()
 
+    fun getDate(timeInMillis: Long): Date {
+        val eventCalendar = Calendar.getInstance()
+        eventCalendar.timeInMillis = timeInMillis
+        return eventCalendar.time
+    }
+
     fun getTimeLeft(timeInMillis: Long): String =
         DateUtils.getRelativeTimeSpanString(timeInMillis).toString()
 
     fun getFormattedTime(timeInMillis: Long): String {
         val formatter: DateFormat = SimpleDateFormat("hh:mm a", Locale.UK)
-        val eventCalendar = Calendar.getInstance()
-        eventCalendar.timeInMillis = timeInMillis
-        return formatter.format(eventCalendar.time)
+        return formatter.format(getDate(timeInMillis))
     }
 }

--- a/app/src/test/java/com/mymeetings/android/db/RoomCalendarEventDataRepositoryTest.kt
+++ b/app/src/test/java/com/mymeetings/android/db/RoomCalendarEventDataRepositoryTest.kt
@@ -65,7 +65,7 @@ class RoomCalendarEventDataRepositoryTest {
 
         coVerify {
             calendarEventsDao.addCalendarEvent(
-                CalendarEventsDbModel(
+                CalendarEventDbModel(
                     title = title,
                     startTime = startTime,
                     endTime = endTime
@@ -96,7 +96,7 @@ class RoomCalendarEventDataRepositoryTest {
         coVerify {
             calendarEventsDao.addCalendarEvents(
                 listOf(
-                    CalendarEventsDbModel(
+                    CalendarEventDbModel(
                         title = title,
                         startTime = startTime,
                         endTime = endTime
@@ -126,7 +126,7 @@ class RoomCalendarEventDataRepositoryTest {
 
         coVerify {
             calendarEventsDao.updateCalendarEvent(
-                CalendarEventsDbModel(
+                CalendarEventDbModel(
                     title = title,
                     startTime = startTime,
                     endTime = endTime

--- a/app/src/test/java/com/mymeetings/android/model/extensions/MapperExtensionsKtTest.kt
+++ b/app/src/test/java/com/mymeetings/android/model/extensions/MapperExtensionsKtTest.kt
@@ -1,9 +1,8 @@
 package com.mymeetings.android.model.extensions
 
 import com.google.common.truth.Truth.assertThat
-import com.mymeetings.android.db.CalendarEventsDbModel
+import com.mymeetings.android.db.CalendarEventDbModel
 import com.mymeetings.android.model.CalendarEvent
-import com.mymeetings.android.model.CalendarEventPriority
 import org.junit.Test
 
 class MapperExtensionsKtTest {
@@ -14,7 +13,6 @@ class MapperExtensionsKtTest {
         val title = "ABC"
         val startTime = 1L
         val endTime = 2L
-        val priority = CalendarEventPriority.MEDIUM
         val isDeleted = false
 
         val calendarEvent = CalendarEvent(
@@ -22,11 +20,10 @@ class MapperExtensionsKtTest {
             title = title,
             startTime = startTime,
             endTime = endTime,
-            priority = priority,
             isDeleted = isDeleted
         )
 
-        val expectedData = CalendarEventsDbModel(
+        val expectedData = CalendarEventDbModel(
             id = id,
             title = title,
             startTime = startTime,
@@ -45,7 +42,7 @@ class MapperExtensionsKtTest {
         val endTime = 2L
         val isDeleted = false
 
-        val calendarEvent = CalendarEventsDbModel(
+        val calendarEvent = CalendarEventDbModel(
             id = id,
             title = title,
             startTime = startTime,

--- a/app/src/test/java/com/mymeetings/android/utils/ClockUtilsTest.kt
+++ b/app/src/test/java/com/mymeetings/android/utils/ClockUtilsTest.kt
@@ -1,29 +1,39 @@
 package com.mymeetings.android.utils
 
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.spyk
 import org.junit.Test
 import java.util.*
 
 class ClockUtilsTest {
 
-    private val UTC_TIME_ZONE = TimeZone.getTimeZone("Europe/London")
+    private val clockUtils = spyk(ClockUtils())
 
     @Test
     fun `getFormattedTime should format time as hh mm a pattern for AM`() {
+        val expectedFormattedTime = "10:10 AM"
         val timeInMillis = 1579495210000
-        val expectedFormattedTime = "10:10 AM" // for GMT +5.30
+        every {
+            clockUtils.getDate(timeInMillis)
+        } returns Date(2020, 1, 1, 10, 10)
 
-        val actualFormattedTime = ClockUtils().getFormattedTime(timeInMillis)
+
+        val actualFormattedTime = clockUtils.getFormattedTime(timeInMillis)
 
         assertThat(actualFormattedTime).isEqualTo(expectedFormattedTime)
     }
 
     @Test
     fun `getFormattedTime should format time as hh mm a pattern for PM`() {
+        val expectedFormattedTime = "07:50 PM"
         val timeInMillis = 1579530080000
-        val expectedFormattedTime = "07:51 PM" // for GMT +5.30
+        every {
+            clockUtils.getDate(timeInMillis)
+        } returns Date(2020, 1, 1, 19, 50)
 
-        val actualFormattedTime = ClockUtils().getFormattedTime(timeInMillis)
+
+        val actualFormattedTime = clockUtils.getFormattedTime(timeInMillis)
 
         assertThat(actualFormattedTime).isEqualTo(expectedFormattedTime)
     }


### PR DESCRIPTION
This PR achieves the following:
- Break up `getFormattedTime()` and modularize into `getDate()` in `ClockUtils` for better testability
- Fix compilation issues